### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tajjacob/2bd6ecd0-1305-40a5-85c8-de94d9dcf337/ec52045a-0665-4683-b718-501ec808eab0/_apis/work/boardbadge/9d748149-7c14-4297-9c98-6f1e96a145cb)](https://dev.azure.com/tajjacob/2bd6ecd0-1305-40a5-85c8-de94d9dcf337/_boards/board/t/ec52045a-0665-4683-b718-501ec808eab0/Microsoft.RequirementCategory)
 # example
 
 A new Flutter project.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tajjacob/2bd6ecd0-1305-40a5-85c8-de94d9dcf337/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.